### PR TITLE
Update to ElasticSearch 2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:2.2
+FROM elasticsearch:2.3
 WORKDIR /usr/share/elasticsearch
 RUN bin/plugin install cloud-aws
 RUN bin/plugin install mobz/elasticsearch-head

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:2.3
+FROM elasticsearch:2.4
 WORKDIR /usr/share/elasticsearch
 RUN bin/plugin install cloud-aws
 RUN bin/plugin install mobz/elasticsearch-head


### PR DESCRIPTION
In order to use the latest version of Kibana, we need ElasticSearch >= 2.3

Update (stepping up) from ElasticSearch 2.2 to 2.4.
